### PR TITLE
解决didMoveToParentViewController:不调用的问题

### DIFF
--- a/RTRootNavigationController/Classes/RTRootNavigationController.m
+++ b/RTRootNavigationController/Classes/RTRootNavigationController.m
@@ -187,7 +187,6 @@ __attribute((overloadable)) static inline UIViewController *RTSafeWrapViewContro
             self.containerNavigationController.viewControllers = @[controller];
         
         [self addChildViewController:self.containerNavigationController];
-        [self.containerNavigationController didMoveToParentViewController:self];
     }
     return self;
 }
@@ -222,7 +221,6 @@ __attribute((overloadable)) static inline UIViewController *RTSafeWrapViewContro
     if (self) {
         self.contentViewController = controller;
         [self addChildViewController:self.contentViewController];
-        [self.contentViewController didMoveToParentViewController:self];
     }
     return self;
 }
@@ -330,6 +328,20 @@ __attribute((overloadable)) static inline UIViewController *RTSafeWrapViewContro
 - (UITabBarItem *)tabBarItem
 {
     return self.contentViewController.tabBarItem;
+}
+
+-(void)willMoveToParentViewController:(UIViewController *)parent
+{
+    [super willMoveToParentViewController:parent];
+    if (parent) return;
+    [self.contentViewController willMoveToParentViewController:parent];
+}
+
+-(void)didMoveToParentViewController:(UIViewController *)parent
+{
+    [super didMoveToParentViewController:parent];
+    if (parent) return;
+    [self.contentViewController didMoveToParentViewController:parent];
 }
 
 @end


### PR DESCRIPTION
更改：重写了RTContainerController类的'willMoveToParentViewController:'和'didMoveToParentViewController:'方法，  删除了'initWithContentController:'和'initWithController:navigationBarClass:withPlaceholderController:backBarButtonItem:backTitle:'中对'didMoveToParentViewController:'方法的手动调用

更改说明：其实当parent != nil时，contentViewController的'willMoveToParentViewController:'和'didMoveToParentViewController:'方法是会由系统自动调用的，不需要处理，当parent == nil时，经测试不会调用，所以这时需要手动调用contentViewController的对应方法

我也不知道这样修改是否有问题，也不知道这样能否解决作者所说的顺序问题，望作者多加测试，辛苦！