### PR TITLE
fix(ci): pass --version to pod lib lint with git describe fallback

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -22,4 +22,7 @@ jobs:
           scheme: ${{ 'default' }}
         run: |
           bundle install
-          bundle exec pod lib lint
+          # Fallback to the latest known tag when git describe cannot resolve one
+          # (e.g. PRs from forks where the runner cannot fetch origin tags).
+          VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo '0.8.1')
+          bundle exec pod lib lint --version="$VERSION"


### PR DESCRIPTION
## 问题

`RTRootNavigationController.podspec` 的 version 来源：

```ruby
s.version = `git describe --abbrev=0`.strip
```

PR 来自 fork 时，CI runner 上的 GITHUB_TOKEN **拿不到** origin 的 tags（fork PR 的安全模型 + 只读 token）。`git describe --abbrev=0` 返回空 → `pod lib lint` 报 `version: A version is required`。

后果：**所有来自 fork 的 PR（包括 Dependabot 自动 bump）CI 100% 失败**。目前 open 着的 #316/#317/#318 三个 dep-bump PR 全是因此失败。

## 修复

Lint step 解析 version 时加 fallback，并把解析结果显式传给 `pod lib lint`：

```yaml
- name: Lint
  env:
    scheme: ${{ 'default' }}
  run: |
    bundle install
    VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo '0.8.1')
    bundle exec pod lib lint --version="$VERSION"
```

- 优先用 `git describe`（push 到 master 时 runner 拿得到 tag）
- fallback 到最新的已知 release tag（0.8.1）—— fork PR 时用
- `pod lib lint --version=...` 显式覆盖 podspec 里的 git describe，validation 永远用真实 version

## 范围

- 1 个文件，4 行新增 / 1 行删除
- 不改 podspec
- 不改 build step（这个 workflow 现在只跑 lint 不跑 xcodebuild，**与本 PR 无关**）
- 不动其他 workflow / 不动 Dependabot 配置

## 关联 PR

- #316, #317, #318 三个 dep-bump PR：本 PR 合后 rebase 即可跑绿

## diff 摘要

```
.github/workflows/objective-c-xcode.yml | 5 ++++-
1 file changed, 4 insertions(+), 1 deletion(-)
```